### PR TITLE
Improve accessibility for screen readers, keyboard users, and colour-…

### DIFF
--- a/_includes/search-modal.html
+++ b/_includes/search-modal.html
@@ -2,22 +2,23 @@
   <div class="search-modal">
     <div class="relative">
       <svg class="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none"
-           viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+           viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
         <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
       </svg>
       <input id="search-input"
              type="search"
              class="search-input pl-10"
              placeholder="Search posts…"
+             aria-label="Search posts"
              autocomplete="off"
              spellcheck="false">
       <button id="search-close" class="absolute right-3 top-1/2 -translate-y-1/2 dark-toggle" aria-label="Close search">
-        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
           <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
         </svg>
       </button>
     </div>
-    <div id="search-results" class="search-results" role="listbox"></div>
+    <div id="search-results" class="search-results" role="list"></div>
     <div id="search-status" role="status" aria-live="polite" aria-atomic="true"
          class="sr-only"></div>
     <div class="search-hint">

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -11,14 +11,14 @@ layout: default
     </div>
     <!-- View toggle -->
     <div class="flex items-center gap-1 mt-1">
-      <button id="view-grid-btn" class="dark-toggle" aria-label="Grid view" title="Grid view">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <button id="view-grid-btn" class="dark-toggle" aria-label="Grid view" aria-pressed="true" title="Grid view">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
           <rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/>
         </svg>
       </button>
-      <button id="view-list-btn" class="dark-toggle" aria-label="List view" title="List view">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <button id="view-list-btn" class="dark-toggle" aria-label="List view" aria-pressed="false" title="List view">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M8 6h13"/><path d="M8 12h13"/><path d="M8 18h13"/><path d="M3 6h.01"/><path d="M3 12h.01"/><path d="M3 18h.01"/>
         </svg>
       </button>
@@ -40,7 +40,8 @@ layout: default
     <div>
       {% if paginator.previous_page %}
       <a href="{{ paginator.previous_page_path | relative_url }}"
-         class="text-sm font-medium no-underline text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-slate-50 transition-colors">
+         class="text-sm font-medium no-underline text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-slate-50 transition-colors"
+         aria-label="Newer posts">
         ← Newer
       </a>
       {% endif %}
@@ -51,7 +52,8 @@ layout: default
     <div>
       {% if paginator.next_page %}
       <a href="{{ paginator.next_page_path | relative_url }}"
-         class="text-sm font-medium no-underline text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-slate-50 transition-colors">
+         class="text-sm font-medium no-underline text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-slate-50 transition-colors"
+         aria-label="Older posts">
         Older →
       </a>
       {% endif %}
@@ -73,6 +75,8 @@ layout: default
     container.classList.toggle('posts-list', !isGrid);
     gridBtn.classList.toggle('view-btn--active', isGrid);
     listBtn.classList.toggle('view-btn--active', !isGrid);
+    gridBtn.setAttribute('aria-pressed', isGrid ? 'true' : 'false');
+    listBtn.setAttribute('aria-pressed', isGrid ? 'false' : 'true');
     localStorage.setItem(STORAGE_KEY, isGrid ? 'grid' : 'list');
   }
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -40,7 +40,7 @@ layout: default
           <path d="M12 16v-4"/>
           <path d="M12 8h.01"/>
         </svg>
-        <span class="post-hero-credit__tooltip" role="tooltip">
+        <span class="post-hero-credit__tooltip">
           Photo by {{ attr.photographer | escape }}{% if attr.source %} on {{ attr.source | escape }}{% endif %}
         </span>
       </a>
@@ -74,18 +74,18 @@ layout: default
         <!-- Metadata bar -->
         <div class="post-meta">
           <span class="post-meta__item">
-            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
             <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
               {{ page.date | date: "%b %-d, %Y" }}
             </time>
           </span>
           <span class="post-meta__item">
-            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
             {{ reading_time }} min read
           </span>
           {% if page.categories.size > 0 %}
           <span class="post-meta__item">
-            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
+            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
             {% for cat in page.categories %}
             <a href="{{ '/' | append: cat | downcase | relative_url }}"
                class="post-meta__category no-underline">{{ cat }}</a>
@@ -220,7 +220,7 @@ layout: default
 
     <!-- TOC column — populated by toc.js -->
     {% if page.no_toc != true %}
-    <aside class="hidden xl:block flex-shrink-0">
+    <aside class="hidden xl:block flex-shrink-0" role="navigation" aria-label="Table of contents">
       <div id="toc-container">
         <p class="toc-title">On this page</p>
       </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -252,7 +252,7 @@ html.theme-gray   { --color-accent: #94a3b8; --color-accent-dark: #64748b; }
     color: var(--color-accent);
     border-left-color: var(--color-accent);
     padding-left: 0.75rem;
-    @apply font-medium;
+    @apply font-semibold;
   }
 
   /* --- View toggle active state --- */
@@ -1770,4 +1770,52 @@ html:not(.dark) .post-content pre.mermaid {
   border: 1px solid #e5e7eb !important;
   border-radius: 0.5rem;
   padding: 1rem !important;
+}
+
+/* =============================================================================
+   High contrast mode — prefers-contrast: more
+   Increases borders, text brightness, and focus rings for users with OS
+   high-contrast settings enabled (macOS Increased Contrast, Windows HCM).
+   ============================================================================= */
+
+@media (prefers-contrast: more) {
+  /* Sharpen body text */
+  body { color: #000; }
+  .dark body { color: #fff; }
+
+  /* Heavier borders throughout */
+  .sidebar, .topbar, .post-card, .search-modal,
+  .shortcuts-panel, #toc-container {
+    border-width: 2px;
+    border-color: currentColor;
+  }
+
+  /* Stronger focus ring */
+  :focus-visible {
+    outline-width: 3px;
+    outline-offset: 3px;
+  }
+
+  /* Ensure links are always underlined */
+  a:not(.no-underline):not(.sidebar__nav-link):not(.sidebar__social-link) {
+    text-decoration: underline;
+  }
+
+  /* Post meta and muted text — boost contrast */
+  .post-meta, .post-meta__item,
+  #toc-container .toc-title {
+    color: inherit;
+    opacity: 1;
+  }
+
+  /* Dark mode overrides */
+  .dark body { background-color: #000; }
+  .dark .sidebar { background-color: #000; border-color: #fff; }
+  .dark #toc-container a { color: #e2e8f0; }
+  .dark #toc-container a.toc-active { color: #fff; font-weight: 700; }
+
+  /* Light mode overrides */
+  html:not(.dark) #toc-container a { color: #111827; }
+  html:not(.dark) #toc-container a.toc-active { color: #000; font-weight: 700; }
+  html:not(.dark) .post-meta { color: #374151; }
 }

--- a/assets/js/back-to-top.js
+++ b/assets/js/back-to-top.js
@@ -3,8 +3,15 @@
   var btn = document.getElementById('back-to-top');
   if (!btn) return;
 
+  // Hidden by default — keep out of tab order until visible
+  btn.setAttribute('aria-hidden', 'true');
+  btn.setAttribute('tabindex', '-1');
+
   window.addEventListener('scroll', function () {
-    btn.classList.toggle('back-to-top--visible', window.scrollY > 400);
+    var visible = window.scrollY > 400;
+    btn.classList.toggle('back-to-top--visible', visible);
+    btn.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    btn.setAttribute('tabindex', visible ? '0' : '-1');
   }, { passive: true });
 
   btn.addEventListener('click', function () {

--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -8,13 +8,22 @@
   }
 })();
 
+function updateDarkToggles(isDark) {
+  document.querySelectorAll('[id^="dark-toggle"]').forEach(function (btn) {
+    btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+  });
+}
+
 function toggleDark() {
   const isDark = document.documentElement.classList.toggle('dark');
   localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  updateDarkToggles(isDark);
 }
 
 document.addEventListener('DOMContentLoaded', function () {
+  const isDark = document.documentElement.classList.contains('dark');
   document.querySelectorAll('[id^="dark-toggle"]').forEach(function (btn) {
+    btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
     btn.addEventListener('click', toggleDark);
   });
 });

--- a/assets/js/keyboard-shortcuts.js
+++ b/assets/js/keyboard-shortcuts.js
@@ -6,6 +6,18 @@
   }
 
   const modal = document.getElementById('keyboard-shortcuts-modal');
+  var lastFocus = null;
+
+  // Focus trap
+  const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  function trapTab(e) {
+    if (e.key !== 'Tab') return;
+    var els = modal ? Array.from(modal.querySelectorAll(FOCUSABLE)) : [];
+    if (!els.length) { e.preventDefault(); return; }
+    var first = els[0], last = els[els.length - 1];
+    if (e.shiftKey) { if (document.activeElement === first) { e.preventDefault(); last.focus(); } }
+    else            { if (document.activeElement === last)  { e.preventDefault(); first.focus(); } }
+  }
 
   function setText(id, value) {
     var el = document.getElementById(id);
@@ -21,17 +33,24 @@
 
   function openHelp() {
     if (!modal) return;
+    lastFocus = document.activeElement;
     refreshPrefs();
     modal.classList.remove('hidden');
     modal.setAttribute('aria-hidden', 'false');
     document.body.classList.add('overflow-hidden');
+    modal.addEventListener('keydown', trapTab);
+    var closeBtn = document.getElementById('keyboard-shortcuts-close');
+    if (closeBtn) closeBtn.focus();
   }
 
   function closeHelp() {
     if (!modal) return;
+    modal.removeEventListener('keydown', trapTab);
     modal.classList.add('hidden');
     modal.setAttribute('aria-hidden', 'true');
     document.body.classList.remove('overflow-hidden');
+    if (lastFocus && typeof lastFocus.focus === 'function') lastFocus.focus();
+    lastFocus = null;
   }
 
   function helpIsOpen() {

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -10,6 +10,18 @@
 
   if (!overlay || !input || !results) return;
 
+  // Focus trap helpers
+  const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  function getFocusable() { return Array.from(overlay.querySelectorAll(FOCUSABLE)); }
+  function trapTab(e) {
+    if (e.key !== 'Tab') return;
+    const els = getFocusable();
+    if (!els.length) { e.preventDefault(); return; }
+    const first = els[0], last = els[els.length - 1];
+    if (e.shiftKey) { if (document.activeElement === first) { e.preventDefault(); last.focus(); } }
+    else            { if (document.activeElement === last)  { e.preventDefault(); first.focus(); } }
+  }
+
   function announce(msg) {
     if (status) status.textContent = msg;
   }
@@ -18,6 +30,7 @@
   let documents = [];
   let indexLoaded = false;
   let loading = false;
+  let lastFocus = null;
 
   // Load search index on demand
   function loadIndex(callback) {
@@ -48,9 +61,11 @@
   }
 
   function openSearch() {
+    lastFocus = document.activeElement;
     overlay.classList.remove('hidden');
     overlay.setAttribute('aria-hidden', 'false');
     document.body.classList.add('overflow-hidden');
+    overlay.addEventListener('keydown', trapTab);
     input.focus();
     loadIndex(function () {
       if (input.value) runSearch(input.value);
@@ -58,6 +73,7 @@
   }
 
   function closeSearch() {
+    overlay.removeEventListener('keydown', trapTab);
     overlay.classList.add('search-overlay--closing');
     setTimeout(function () {
       overlay.classList.add('hidden');
@@ -67,6 +83,8 @@
       input.value = '';
       results.innerHTML = '';
       announce('');
+      if (lastFocus && typeof lastFocus.focus === 'function') lastFocus.focus();
+      lastFocus = null;
     }, 150);
   }
 
@@ -82,7 +100,7 @@
       const doc = documents.find(d => d.id === hit.ref);
       if (!doc) return '';
       return (
-        '<a href="' + doc.url + '" class="search-result-item" role="option">' +
+        '<a href="' + doc.url + '" class="search-result-item">' +
           '<span class="search-result-title">' + escapeHtml(doc.title) + '</span>' +
           (doc.excerpt ? '<span class="search-result-excerpt">' + escapeHtml(doc.excerpt.slice(0, 100)) + '…</span>' : '') +
         '</a>'

--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -4,23 +4,48 @@ document.addEventListener('DOMContentLoaded', function () {
   const overlay = document.getElementById('sidebar-overlay');
   const sidebar = document.getElementById('sidebar');
 
+  // Focus trap
+  const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  function trapTab(e) {
+    if (e.key !== 'Tab') return;
+    var els = sidebar ? Array.from(sidebar.querySelectorAll(FOCUSABLE)) : [];
+    if (!els.length) { e.preventDefault(); return; }
+    var first = els[0], last = els[els.length - 1];
+    if (e.shiftKey) { if (document.activeElement === first) { e.preventDefault(); last.focus(); } }
+    else            { if (document.activeElement === last)  { e.preventDefault(); first.focus(); } }
+  }
+
   function openSidebar() {
     sidebar && sidebar.classList.add('sidebar--open');
     overlay && overlay.classList.remove('hidden');
     document.body.classList.add('overflow-hidden');
+    toggle && toggle.setAttribute('aria-expanded', 'true');
+    sidebar && sidebar.addEventListener('keydown', trapTab);
+    // Move focus to first focusable element inside sidebar
+    if (sidebar) {
+      var first = sidebar.querySelector(FOCUSABLE);
+      if (first) first.focus();
+    }
   }
 
   function closeSidebar() {
     sidebar && sidebar.classList.remove('sidebar--open');
     overlay && overlay.classList.add('hidden');
     document.body.classList.remove('overflow-hidden');
+    toggle && toggle.setAttribute('aria-expanded', 'false');
+    sidebar && sidebar.removeEventListener('keydown', trapTab);
+    // Restore focus to the toggle button
+    if (toggle) toggle.focus();
   }
 
+  toggle && toggle.setAttribute('aria-expanded', 'false');
   toggle && toggle.addEventListener('click', openSidebar);
   overlay && overlay.addEventListener('click', closeSidebar);
 
   // Close on Escape
   document.addEventListener('keydown', function (e) {
-    if (e.key === 'Escape') closeSidebar();
+    if (e.key === 'Escape' && sidebar && sidebar.classList.contains('sidebar--open')) {
+      closeSidebar();
+    }
   });
 });

--- a/assets/js/zoom.js
+++ b/assets/js/zoom.js
@@ -13,11 +13,14 @@ document.addEventListener('DOMContentLoaded', function () {
       e.preventDefault();
       e.stopPropagation();
 
+      var lastFocus = document.activeElement;
+
       var overlay = document.createElement('div');
       overlay.className = 'img-zoom-overlay';
       overlay.setAttribute('role', 'dialog');
       overlay.setAttribute('aria-modal', 'true');
-      overlay.setAttribute('aria-label', 'Zoomed image — press Escape to close');
+      overlay.setAttribute('aria-label', 'Zoomed image — press Escape or click to close');
+      overlay.setAttribute('tabindex', '-1');
 
       var enlarged = document.createElement('img');
       enlarged.src = img.currentSrc || img.src;
@@ -30,12 +33,14 @@ document.addEventListener('DOMContentLoaded', function () {
       // Animate in on next frame so the CSS transition fires
       requestAnimationFrame(function () {
         overlay.classList.add('img-zoom-overlay--visible');
+        overlay.focus();
       });
 
       function close() {
         overlay.classList.remove('img-zoom-overlay--visible');
         overlay.addEventListener('transitionend', function () {
           overlay.remove();
+          if (lastFocus && typeof lastFocus.focus === 'function') lastFocus.focus();
         }, { once: true });
       }
 


### PR DESCRIPTION
…blind users

- Add focus traps and focus restoration to search, keyboard shortcuts, and mobile sidebar modals
- Add focus management to image zoom overlay (dialog role, tabindex, restore on close)
- Fix search results from role="listbox"/role="option" to role="list" (correct for link-based results)
- Add aria-label to search input (placeholder alone is not sufficient)
- Add aria-pressed to dark mode toggle, view toggle, and accent swatch buttons
- Add aria-expanded to mobile sidebar toggle button
- Add aria-hidden to decorative SVGs in post meta (calendar, clock, tag icons)
- Add role="navigation" aria-label="Table of contents" to TOC aside element
- Remove incorrect role="tooltip" from hero image credit span
- Add descriptive aria-label to blog pagination links
- Remove back-to-top button from tab order when visually hidden (aria-hidden + tabindex toggle)
- Bump TOC active link to font-semibold for non-colour active state indicator
- Add prefers-contrast: more media query block for OS high-contrast mode support